### PR TITLE
Allow single dot to return entire payload value

### DIFF
--- a/octoprint_IFTTT/__init__.py
+++ b/octoprint_IFTTT/__init__.py
@@ -47,7 +47,10 @@ class IFTTTplugin(
             return to_thunk("")
 
         if value[0] == ".":
-            return to_thunk(payload[value[1:]])
+			if value[1:]
+            	return to_thunk(payload[value[1:]])
+			else
+				return to_thunk(payload);
 
         if value[0] == ":":
             return to_thunk(value[1:])


### PR DESCRIPTION
Allow "." to return the entire payload. This is useful for plugins like https://github.com/derekantrican/OctoPrint-ngrok that don't send a json/dict event payload and instead just send a single argument