### PR TITLE
Add Python compatibility string for Python 2 & 3

### DIFF
--- a/octoprint_IFTTT/__init__.py
+++ b/octoprint_IFTTT/__init__.py
@@ -22,9 +22,9 @@ class IFTTTplugin(
         for event in events:
             if event["event_name"] != event_name: continue
 
-            trigger_names = filter(lambda name: name.strip(), event["trigger_names"])
+            trigger_names = list(filter(lambda name: name.strip(), event["trigger_names"]))
 
-            if not len(trigger_names):
+            if not trigger_names:
                 trigger_names = [prefix + event_name for prefix in default_prefixes]
 
             value_thunks = [self._interpret_value(event_payload, value) for value in event["values"] + [""] * (3 - len(event["values"]))]
@@ -68,10 +68,10 @@ class IFTTTplugin(
                 sf = s.zfill(2)
                 mf = m.zfill(2)
                 hf = h.zfill(2)
-                
+
                 if value[2] == "$":
                     return to_thunk('%s:%s:%s' % (hf, mf, sf))
-                    
+
                 if value[2] == ":":
                     return to_thunk('%s:%s' % (hf, mf))
 

--- a/octoprint_IFTTT/__init__.py
+++ b/octoprint_IFTTT/__init__.py
@@ -127,6 +127,7 @@ class IFTTTplugin(
         )
 
 __plugin_name__ = "OctoPrint-IFTTT"
+__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
✅ Tested!
The plugin's source passes my reading of what is required to run under Python 3, so I added the compatibility string.

Since Python 2 is end-of-life and new users will be installing on Python 3, and existing users upgrading, this plugin will no longer work for them. And at some point next year, OctoPrint core will drop Python 2 support. 

This fix adds the line:
```python
__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
```
so that it lets OctoPrint know that this will work on Py2.

Apologies, it is not tested. If anyone would like to test it and feedback that it works/doesn't, please do so!

Documentation for plugin authors re. migrating to Python 3; https://docs.octoprint.org/en/master/plugins/python3_migration.html#migrating-to-python-3

Edit:
Closes #28
Closes #30 
Closes #31 
Closes #32 
Closes #33 
Closes #34