### PR TITLE
Added ability to specify and call a custom webhook instead of specifying maker keys

### DIFF
--- a/octoprint_IFTTT/__init__.py
+++ b/octoprint_IFTTT/__init__.py
@@ -34,7 +34,7 @@ class IFTTTplugin(
             for trigger_name in trigger_names:
                 if webhook:
                     payload = payload_thunk()
-                    self._logger.info("sending a request to url: %s, payload: %s" % (webhook, payload));
+                    self._logger.info("sending a request to url: %s, payload: %s" % (webhook, payload))
 
                     response = requests.post(webhook, json=payload)
                     self._logger.info("response: " + response.text)
@@ -99,6 +99,7 @@ class IFTTTplugin(
     def get_settings_defaults(self):
         return dict(
             makerkeys=[],
+            webhook="",
             default_prefixes = ["OctoPrint-", "op-"],
             events=[
                 dict(event_name="PrintDone", trigger_names=[], values=[".name", ".time", ".origin"]),

--- a/octoprint_IFTTT/__init__.py
+++ b/octoprint_IFTTT/__init__.py
@@ -18,6 +18,7 @@ class IFTTTplugin(
         events = self._settings.get(["events"])
         default_prefixes = self._settings.get(["default_prefixes"])
         makerkeys = self._settings.get(["makerkeys"])
+        webhook = self._settings.get(["webhook"])
 
         for event in events:
             if event["event_name"] != event_name: continue
@@ -31,6 +32,13 @@ class IFTTTplugin(
             payload_thunk = lambda: { "value1": value_thunks[0](), "value2": value_thunks[1](), "value3": value_thunks[2]() }
 
             for trigger_name in trigger_names:
+                if webhook:
+                    payload = payload_thunk()
+                    self._logger.info("sending a request to url: %s, payload: %s" % (webhook, payload));
+
+                    response = requests.post(webhook, json=payload)
+                    self._logger.info("response: " + response.text)
+
                 for makerkey in makerkeys:
                     payload = payload_thunk()
                     url = "https://maker.ifttt.com/trigger/%s/with/key/%s" % (trigger_name, makerkey)

--- a/octoprint_IFTTT/static/js/IFTTT.js
+++ b/octoprint_IFTTT/static/js/IFTTT.js
@@ -9,6 +9,11 @@ $(function() {
 			write: mks => self.startupComplete() && self.settings.makerkeys(mks.split("\n")),
 		});
 
+		self.webhook = ko.computed({
+			read: () => self.startupComplete() && self.settings.webhook(),
+			write: mks => self.startupComplete() && self.settings.webhook(mks),
+		});
+
 		self.defaultPrefixes = ko.computed({
 			read: () => self.startupComplete() && self.settings.default_prefixes().join("\n"),
 			write: dps => self.startupComplete() && self.settings.default_prefixes(dps.split("\n")),

--- a/octoprint_IFTTT/templates/IFTTT_settings.jinja2
+++ b/octoprint_IFTTT/templates/IFTTT_settings.jinja2
@@ -1,9 +1,15 @@
 <form class="form-horizontal">
-	<h4>{{ _('Makerkeys') }}</h4>
+	<h4>{{ _('Makerkeys-Webhook') }}</h4>
 	<div class="control-group">
 		<label class="control-label">{{ _('Makerkeys') }}</label>
 		<div class="controls">
 			<textarea data-bind="value: makerkeys"></textarea>
+		</div>
+	</div>
+	<div class="control-group">
+		<label class="control-label">{{ _('Webhook') }}</label>
+		<div class="controls">
+			<textarea data-bind="value: webhook"></textarea>
 		</div>
 	</div>
 	<h4>{{ _('Default Prefixes') }}</h4>


### PR DESCRIPTION
Resolves #39 

Let me know if you have any additional things you would like me to add. I am unfamiliar with Python, Octoprint webhooks, and the various "languages" used here (eg jinja & KnockoutJS) so I made what changes I could, but there could be other things missing. Some things I noticed that might need to be updated:

- translations? (not sure what the process is for that)
- Readme (looks like there's two - I imagine one is for this repo and one is for the plugin page)
- plugin version
- in testing, I realized that the webhook will get fired twice if you have 2 prefixes (eg the default "OctoPrint-" & "op-". Not sure if we want to add the key to the webhook url or somehow include the key in the payload so that this doesn't cause confusion